### PR TITLE
fix: Remove --version flag from golangci-lint on Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ lint:
 	@hash golangci-lint > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.39.0; \
 	fi
-	golangci-lint run --version
+	golangci-lint run
 
 .PHONY: test
 test:


### PR DESCRIPTION
Signed-off-by: Alexandre Ferreira <alexjorgef@protonmail.com>